### PR TITLE
Ee 21428 configurable image versions (or not)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ services:
     image: selenium/standalone-chrome
 
   ui:
-    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:{{.UI-IMAGE-VERSION}}
+    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:latest
     environment:
       - API_ROOT=http://api:8081
       - FEEDBACK_ROOT=http://feedback:8080

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ pipeline:
     commands:
       - ./gradlew test
     when:
-      branches: [ master ]
+      branches: [ master, EE-21428-configurable-image-versions ]
       event: push
 
 services:
@@ -14,7 +14,7 @@ services:
     image: selenium/standalone-chrome
 
   ui:
-    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:build-294
+    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:{{.UI-IMAGE-VERSION}}
     environment:
       - API_ROOT=http://api:8081
       - FEEDBACK_ROOT=http://feedback:8080

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,29 +14,29 @@ services:
     image: selenium/standalone-chrome
 
   ui:
-    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:$${UI_VERSION=latest}
+    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:latest
     environment:
       - API_ROOT=http://api:8081
       - FEEDBACK_ROOT=http://feedback:8080
 
   api:
-    image: quay.io/ukhomeofficedigital/pttg-ip-api:build-744
+    image: quay.io/ukhomeofficedigital/pttg-ip-api:latest
     environment:
       - HMRC_SERVICE_URL=http://hmrc:8100
       - PTTG_AUDIT_URL=http://audit:8083
 
   audit:
-    image: quay.io/ukhomeofficedigital/pttg-ip-audit:build-435
+    image: quay.io/ukhomeofficedigital/pttg-ip-audit:latest
 
   hmrc:
-    image: quay.io/ukhomeofficedigital/pttg-ip-hmrc:build-1197
+    image: quay.io/ukhomeofficedigital/pttg-ip-hmrc:latest
     environment:
       - BASE_HMRC_ACCESS_CODE_URL=http://hmrc-access:8090
       - PTTG_AUDIT_URL=http://audit:8083
       - BASE_HMRC_URL=http://test:8111
 
   hmrc-access:
-    image: quay.io/ukhomeofficedigital/pttg-ip-hmrc-access-code:build-191
+    image: quay.io/ukhomeofficedigital/pttg-ip-hmrc-access-code:latest
     environment:
       - PTTG_AUDIT_URL=http://audit:8083
       - BASE_HMRC_URL=http://test:8111

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ services:
     image: selenium/standalone-chrome
 
   ui:
-    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:$${UI_VERSION}
+    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:$${UI_VERSION=latest}
     environment:
       - API_ROOT=http://api:8081
       - FEEDBACK_ROOT=http://feedback:8080

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ services:
     image: selenium/standalone-chrome
 
   ui:
-    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:latest
+    image: quay.io/ukhomeofficedigital/pttg-ip-fm-ui:$${UI_VERSION}
     environment:
       - API_ROOT=http://api:8081
       - FEEDBACK_ROOT=http://feedback:8080

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ pipeline:
     commands:
       - ./gradlew test
     when:
-      branches: [ master, EE-21428-configurable-image-versions ]
+      branches: [ master ]
       event: push
 
 services:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # pttg-ip-e2e-tests
 IPS end to end integration test suite 
 
-To run the test locally, make sure that you have docker and docker-compose installed, as well as VNC viewer.
+## Running tests locally with Docker
+Make sure that you have docker and docker-compose installed, as well as VNC viewer.
 
 From the project root directory, execute the following command:
 
@@ -28,8 +29,21 @@ http://localhost:8000/#!/familymigration
 
 If tests are run automatically from the docker container, the results will be located in the `out` directory.
 
+## Running tests locally with Drone
+
+If you have Drone CLI 0.8.* installed locally you can run this test suite locally with the command
+`drone exec`.
+
+## Running test in Intellij
 Tests can also be run manually via IntelliJ or command line once the docker-compose is up.
 To run the test manually and see their outcome it's possible to run the VNC Viewer
 and point it at localhost:5900. It shouldn't require a password to connect and if the chrome
 box is up, it will connect to it. Once the tests are kicked off and selenium is triggered, you
 should be able to see the browser appearing into the remote chrome box.
+
+## Testing different versions of components
+Drone does not support configurable image versions for services, therefore it is not possible to trigger 
+the tests specifying exact versions from another Drone job or from the command line.  
+* You can achieve this locally by editing the image versions of components in the docker-compose.yml.  
+* You can achieve this on the Drone server by editing the image versions of components in the .drone.yml file and adding your
+branch to the "test" stage. 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ http://localhost:8000/#!/familymigration
 
 If tests are run automatically from the docker container, the results will be located in the `out` directory.
 
-## Running tests locally with Drone
-
-If you have Drone CLI 0.8.* installed locally you can run this test suite locally with the command
-`drone exec`.
-
 ## Running test in Intellij
 Tests can also be run manually via IntelliJ or command line once the docker-compose is up.
 To run the test manually and see their outcome it's possible to run the VNC Viewer


### PR DESCRIPTION
In Drone it's not possible to have configurable image tags for services.  This will be possible locally with docker-compose, but not on the drone server.
Therefore this ticket changed to just run the "latest" tag for each of the components.  This will at least give us some confidence if we trigger the e2e tests each time a component is merged to master.